### PR TITLE
feat(user data validation): Validate user input during registration

### DIFF
--- a/authors/apps/authentication/backends.py
+++ b/authors/apps/authentication/backends.py
@@ -41,14 +41,15 @@ class JWTAuthentication(authentication.BaseAuthentication):
         successful, return the user and token. If not, throw an error.
         """
         try:
-            payload = jwt.decode(token, config('SECRET_KEY'))
-        finally:
+            payload = jwt.decode(token, config('SECRET_KEY'),
+                                 algorithm='HS256')
+        except Exception:
             msg = 'Invalid authentication. Could not decode token.'
             raise exceptions.AuthenticationFailed(msg)
 
         try:
             user = User.objects.get(pk=payload['id'])
-        except User.DoesNotExist:
+        except user.DoesNotExist:
             msg = 'No user matching this token was found.'
             raise exceptions.AuthenticationFailed(msg)
 

--- a/authors/apps/authentication/models.py
+++ b/authors/apps/authentication/models.py
@@ -136,6 +136,7 @@ class User(AbstractBaseUser, PermissionsMixin):
 
         token = jwt.encode({
             'id': self.pk,
+            'email': self.email,
             'exp': int(expiry_date.strftime('%s'))
         }, config('SECRET_KEY'), algorithm='HS256')
 

--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -66,8 +66,10 @@ class LoginSerializer(serializers.Serializer):
         # If no user was found matching this email/password combination then
         # `authenticate` will return `None`. Raise an exception in this case.
         if user is None:
+            response = "Please signup and check for an activation link \
+                 in your email to activate this account"
             raise serializers.ValidationError(
-                'A user with this email and password was not found.'
+                ' '.join(response.split())
             )
 
         # Django provides a flag on our `User` model called `is_active`. The

--- a/authors/apps/authentication/urls.py
+++ b/authors/apps/authentication/urls.py
@@ -1,11 +1,12 @@
 from django.urls import path
 
 from .views import (
-    LoginAPIView, RegistrationAPIView, UserRetrieveUpdateAPIView
+    LoginAPIView, RegistrationAPIView, UserRetrieveUpdateAPIView, VerifyAccount
 )
 
 urlpatterns = [
     path('user/', UserRetrieveUpdateAPIView.as_view()),
     path('users/', RegistrationAPIView.as_view()),
     path('users/login/', LoginAPIView.as_view()),
+    path('users/verify/', VerifyAccount.as_view()),
 ]

--- a/authors/apps/authentication/validation.py
+++ b/authors/apps/authentication/validation.py
@@ -1,0 +1,63 @@
+import re
+from rest_framework import serializers
+
+
+def validate_registration(data):
+    username = data.get('username', None)
+    email = data.get('email', None)
+    password = data.get('password', None)
+
+    if not (username or password or email):
+        raise serializers.ValidationError(
+            {
+                'input fields':
+                'Please provide a username, email address and a password'
+            }
+        )
+    if not username or len(username.strip()) == 0:
+        raise serializers.ValidationError(
+            {
+                'input fields':
+                'Please input a username'
+            }
+        )
+    if len(username) < 4:
+        raise serializers.ValidationError(
+            {
+                'username':
+                'Please the username should be at'
+                'least 4 characters'
+            }
+        )
+
+    if not re.match(r"^[A-Za-z]+[\d\w_]+", username):
+        raise serializers.ValidationError(
+
+            {
+                'username':
+                'Username should start with letters'
+            }
+        )
+
+    if not re.search(r"([\w\.-]+)@([\w\.-]+)(\.[\w\.]+$)", email):
+        raise serializers.ValidationError(
+            {
+                'Email':
+                'Please enter a valid email address'
+
+            }
+        )
+
+    valid_password(password)
+    return{"username": username, "email": email, "password": password}
+
+
+def valid_password(password):
+    long_password = (len(password) >= 8)
+    atleast_number = re.search("[0-9]", password)
+    Capital_letters = re.search("[A-Z]", password)
+
+    if (not long_password or not atleast_number or not Capital_letters):
+        raise serializers.ValidationError(
+            {'password': 'Password should contain at'
+             'least 8 characters uppercase, number'})

--- a/authors/apps/core/utils.py
+++ b/authors/apps/core/utils.py
@@ -1,0 +1,25 @@
+from django.conf import settings
+from ..authentication.models import User
+from django.contrib.sites.shortcuts import get_current_site
+from django.core.mail import send_mail
+
+
+def send_mail_user(request, serializer):
+    user = request.data.get('user', {})
+    email = user['email']
+    users = User.objects.filter(email=email)
+    users.update(is_active=False)
+    url_param = get_current_site(request).domain
+    email = user['email']
+    send_mail(
+        'Email-verification',
+        'Click here to verify your account {}/api/users/verify?token={}'
+        .format(url_param, serializer.data['token']),
+        settings.EMAIL_HOST_USER,
+        [email],
+        fail_silently=False,
+    )
+    info = """You have successfully been registered,please check \
+        your email for confirmation"""
+    email_verify = {"Message": info, "token": serializer.data['token']}
+    return email_verify

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -123,6 +123,11 @@ REST_FRAMEWORK = {
         'authors.apps.authentication.backends.JWTAuthentication',
     ),
 }
-
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_USE_TLS = True
+EMAIL_HOST = os.environ.get('EMAIL_HOST', '')
+EMAIL_PORT = os.environ.get('EMAIL_PORT', '')
+EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER', '')
+EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD', '')
 
 django_heroku.settings(locals())

--- a/tests/authentication/test_registration.py
+++ b/tests/authentication/test_registration.py
@@ -4,12 +4,20 @@ from rest_framework.test import APITestCase, APIClient
 
 class TestRegistration(APITestCase):
 
+    def registering_with_no_data(self):
+        data = {}
+        response = self.client.post('/api/users/', data, format='json')
+        self.assertEqual(response.data["errors"]["input fields"],
+                         "Please provide a username, email address \
+                          and a password")
+        self.assertEqual(response.status, status.HTTP_400_BAD_REQUEST)
+
     def test_recieve_a_token_after_registration(self):
         data = {
             "user": {
                 "username": "user",
                 "email": "users@gmail.com",
-                "password": "users@2011"
+                "password": "Users@2011"
             }
         }
         response = self.client.post('/api/users/', data, format='json')
@@ -25,15 +33,21 @@ class TestRegistration(APITestCase):
             "user": {
                 "username": "users",
                 "email": "userstest@gmail.com",
-                "password": "users@2011"
+                "password": "Users@2011"
             }
         }
-        response = self.client.post('/api/users/', data, format='json')
-        data = {"user": {
+        registration_response = self.client.post('/api/users/', data,
+                                                 format='json')
+        registration_token = registration_response.data['token']
+        self.client.post('/api/users/verify/?token=' + registration_token,
+                         format='json')
+        login_data = {
+            "user": {
                 "email": "userstest@gmail.com",
-                "password": "users@2011"}
-                }
-        response = self.client.post('/api/users/login/', data, format='json')
+                "password": "Users@2011"}
+        }
+        response = self.client.post('/api/users/login/',
+                                    login_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert 'token' in response.data
 
@@ -65,10 +79,18 @@ class TestRegistration(APITestCase):
         response = client.get("/api/user/", format="json")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_authentication_with_wrong_token_authorization(self):
+        """
+        Test authentication with invalid users
+        """
+        self.client.credentials(HTTP_AUTHORIZATION='ggghghgh' + 'nhjnhjjhhj')
+        response = self.client.get("/api/user/", format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
     def test_unsuccessfull_registration_without_user_name_field(self):
         data = {"user": {
                 "email": "users@gmail.com",
-                "password": "users@2011"}
+                "password": "Users@2011"}
                 }
         response = self.client.post('/api/users/', data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -77,7 +99,7 @@ class TestRegistration(APITestCase):
         client = APIClient()
         token_key = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9. \
             eyJpZCI6MywiZXhwIjoxNTU2NTM4MTgxfQ.sIF_X-yPMENo1T \
-            vTPPj2NHbEW-dYERK4CXdJnbkhb0A'
+            vTPPj2NHbEW-dYERK4CXdJnbkhb0Adsk'
         client.credentials(HTTP_AUTHORIZATION='Bearer' + token_key)
         response = client.get("/api/user/", format="json")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -90,3 +112,17 @@ class TestRegistration(APITestCase):
         # client.credentials(HTTP_AUTHORIZATION= ' ' + 'token')
         response = client.get("/api/user/", format="json")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_verification_email_is_sent(self):
+        data = {
+            "user": {
+                "username": "user",
+                "email": "users@gmail.com",
+                "password": "Users@2011"
+            }
+        }
+        registration_response = self.client.post('/api/users/',
+                                                 data, format='json')
+        token = registration_response.data["token"]
+        response = self.client.post('/api/users/verify/?token=' + token)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/tests/test_validation/test_validation.py
+++ b/tests/test_validation/test_validation.py
@@ -1,0 +1,121 @@
+from rest_framework import status
+from rest_framework.test import APITestCase
+import re
+
+
+class TestValidation(APITestCase):
+
+    def setUp(self):
+        self.user_one = {
+            "user": {
+                "username": "micheal",
+                "email": "micheal@gmail.com",
+                "password": "A1234567a"
+            }
+        }
+        self.user_one_short_username = {
+            "user": {
+                "username": "m",
+                "email": "micheal@gmail.com",
+                "password": "A1234567a"
+            }
+        }
+        self.user_one_bad_username = {
+            "user": {
+                "username": "+msshjbsjhbs",
+                "email": "micheal@gmail.com",
+                "password": "A1234567a"
+            }
+        }
+        self.user_one_short_password = {
+            "user": {
+                "username": "micheal",
+                "email": "micheal@gmail.com",
+                "password": "A123456"
+            }
+        }
+        self.user_one_wrong_email = {
+            "user": {
+                "username": "micheal",
+                "email": "micheal.com",
+                "password": "A1234567a"
+            }
+        }
+        self.user_one_no_alpha = {
+            "user": {
+                "username": "micheal",
+                "email": "micheal@gmail.com",
+                "password": "12345678"
+            }
+        }
+        self.user_one_same_user = {
+            "user": {
+                "username": "micheal",
+                "email": "micheal@gmail.com",
+                "password": "A1234567a"
+            }
+        }
+
+    def test_signing_up_without_data(self):
+        response = self.client.post('/api/users/', data={}, format="json")
+        check_string = "Please provide a username, email \
+             address and a password"
+        self.assertEqual(
+            response.data["errors"]["input fields"],
+            re.sub(' +', ' ', check_string))
+
+    def test_short_username(self):
+        response = self.client.post('/api/users/',
+                                    self.user_one_short_username,
+                                    format='json')
+        data = response.data
+        self.assertEqual(
+            data['errors']
+            ['username'], "Please the username should be atleast 4 characters")
+
+    def test_bad_username(self):
+        response = self.client.post(
+            '/api/users/', self.user_one_bad_username, format='json')
+        data = response.data
+        self.assertEqual(
+            data['errors']
+            ['username'],
+            "Username should start with letters")
+
+    def test_existing_user_email(self):
+        self.client.post('/api/users/', self.user_one, format='json')
+        response = self.client.post(
+            '/api/users/', self.user_one_same_user, format='json')
+        data = response.data
+        self.assertEqual(data['errors']['email'][0],
+                         'user with this email already exists.')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_invalid_email(self):
+        response = self.client.post(
+            '/api/users/', self.user_one_wrong_email, format='json')
+        data = response.data
+        self.assertEqual(data["errors"]["Email"],
+                         'Please enter a valid email address')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_password_of_length_less_than_8(self):
+        response = self.client.post(
+            '/api/users/', self.user_one_short_password, format='json')
+        data = response.data
+        self.assertEqual(
+            data["errors"]
+            ["password"],
+            "Password should contain atleast 8 characters uppercase, number")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_password_not_being_alphanumeric(self):
+        response = self.client.post('/api/users/',
+                                    self.user_one_short_password,
+                                    format='json')
+        data = response.data
+        self.assertEqual(
+            data["errors"]
+            ["password"],
+            "Password should contain atleast 8 characters uppercase, number")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
**What does this PR do ?**
* Adds functionality that validates user input on registration.

**Description of the tasks to be completed?**

    Sends a descriptive validation message when 
 - A user inputs a username that does not start with a letter e.g &^%edgar is not a valid username.
    A valid username would be edgar and it should not be less than 4 letters in length.
- A user inputs a password that is less than 8 letters in length and is not alphanumeric or lacks an uppercase letter.
- A user enters an email that is not vaild, e.g at.com, a valid email would be at@gmail.com

**How should this be manually tested?**
* Visit the Sign up route at /api/users/ , try registering a user with an empty body, or a body without a username field, or password or email, try an email that is not valid.

**What are the relevant pivot tracker stores?**
* #164069307