### PR TITLE
#164069322 Add Search Functionality and Custom filtering based on parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,10 +55,8 @@ coverage.xml
 *.log
 */migrations/*
 local_settings.py
-authors/apps/articles/migrations/0001_initial.py
-authors/apps/articles/migrations/0002_auto_20190315_1729.py
-authors/apps/authentication/migrations/0001_initial.py
-authors/apps/profiles/migrations/0001_initial.py
+*/migrations/*
+authors/apps/*/migrations/*
 
 # Flask stuff:
 instance/

--- a/authors/apps/articles/pagination.py
+++ b/authors/apps/articles/pagination.py
@@ -1,8 +1,6 @@
-from rest_framework.pagination import PageNumberPagination
+from rest_framework.pagination import LimitOffsetPagination
 
 
-class ArticlePagination(PageNumberPagination):
-    page_size = 5
-    page_size_query_param = 'page_size'
-    max_page_size = 100
-    last_page_strings = ('end',)
+class ArticlePagination(LimitOffsetPagination):
+    default_limit = 5
+    max_limit = 100

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -10,7 +10,7 @@ class CategorySerializer(serializers.ModelSerializer):
         model = Category
         fields = (
             'name',
-            'slug',)
+            'slug')
         read_only_fields = ('id', 'slug',)
 
 

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -38,7 +38,9 @@ INSTALLED_APPS = [
     'authors.apps.authentication',
     'authors.apps.core',
     'authors.apps.profiles',
-    'authors.apps.articles'
+    'authors.apps.articles',
+
+    'django_filters',
 ]
 
 MIDDLEWARE = [
@@ -126,6 +128,9 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 10,
+    'DEFAULT_FILTER_BACKENDS': (
+        'django_filters.rest_framework.DjangoFilterBackend',
+        )
 
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ heroku==0.1.4
 Pillow==5.4.1
 django-coverage-plugin==1.6.0
 PyYAML==4.2b1
+django-filter==2.1.0

--- a/tests/articles/test_articles.py
+++ b/tests/articles/test_articles.py
@@ -123,3 +123,13 @@ class TestArticle(BaseTest, TestCategory):
             article_1.data['slug']
         ), format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_can_search_based_on_filters(self):
+        self.create_an_article(self.new_article, self.registration_data)
+        response = self.client.get("/api/articles/?author=user", format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.client.get("/api/articles/?tag=user", format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.client.get("/api/articles/?favorited=user",
+                                   format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
**What does this PR do?**
- user can search for articles by author, article title and tag/keyword or search by filtering.

**How can it be tested?**
- Create an article with `USER_A` here `api/articles` using `POST` method, endeavour to add a taglist.
- Favorite the article using `USER_B`
- Filter favorite articles for `USER_A` here `/api/articles/?favorited=USER_A`
- Filter based on tags used `/api/articles/?tag=whichever_tag`
- Filter based on authors `/api/articles/?author=USER_B`

**What are the relevant PT stories**
[Delivers #164069322]

**Screenshots**

![image](https://user-images.githubusercontent.com/28726900/54490038-90ff8c00-48c3-11e9-9937-3e6d58565dd5.png)


![image](https://user-images.githubusercontent.com/28726900/54490082-e8056100-48c3-11e9-91a7-3a173ab5f8d2.png)


![image](https://user-images.githubusercontent.com/28726900/54490091-f81d4080-48c3-11e9-9e95-90b526b0fc90.png)
