### PR TITLE
#164069329 Track comments edit history

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -147,6 +147,12 @@ class Comment(models.Model):
     body = models.TextField(max_length=500)
 
 
+class CommentHistory(models.Model):
+    comment = models.ForeignKey(Comment, on_delete=models.CASCADE)
+    body = models.TextField()
+    updated_at = models.DateTimeField(auto_now_add=True)
+
+
 class Tag(models.Model):
     tag = models.CharField(max_length=255)
     created_at = models.DateTimeField(auto_now_add=True)

--- a/authors/apps/articles/renderers.py
+++ b/authors/apps/articles/renderers.py
@@ -16,3 +16,7 @@ class BookmarkJSONRenderer(MainRenderer):
 
 class TagJSONRenderer(MainRenderer):
     object_label = 'tag'
+
+
+class CommentHistoryJSONRenderer(MainRenderer):
+    object_label = 'history'

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -8,8 +8,10 @@ from .views import (RetrieveUpdateDestroyCategory,
                     ListBookmarksView, UnBookmarkView,
                     BookmarkView, FavoriteArticle,
                     RetrieveUpdateDestroyComment,
-                    UnFavoriteArticle, RatingsView, PublishArticleUpdate,
-                    CreateReportView)
+                    UnFavoriteArticle, RatingsView,
+                    CreateReportView,
+                    ListCommentHistoryView,
+                    PublishArticleUpdate)
 from .models import LikeDislike, LikeDislikeManager, Article
 
 urlpatterns = [
@@ -54,6 +56,8 @@ urlpatterns = [
          name="get-comments"),
     path('articles/<str:slug>/comments/<int:id>/',
          RetrieveUpdateDestroyComment.as_view(), name="comments-crud"),
+    path('articles/<str:slug>/comments/<int:id>/history/',
+         ListCommentHistoryView.as_view(), name="comment-history"),
 
     path('tags/', ListTagsView.as_view(),
          name='tags'),

--- a/authors/apps/renderers.py
+++ b/authors/apps/renderers.py
@@ -23,6 +23,11 @@ class MainRenderer(JSONRenderer):
             })
 
         else:
+            if(self.object_label == 'history'):
+                return json.dumps({
+                    self.object_label: data
+                })
+
             return json.dumps({
                 self.object_label + 's': data
             })

--- a/tests/articles/test_comments.py
+++ b/tests/articles/test_comments.py
@@ -71,3 +71,37 @@ class TestComment(BaseTest, TestCategory):
     def test_commenting_without_logging_in(self):
         get_response = self.client.get("/api/articles/sbsbds/comments/")
         self.assertEqual(get_response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_get_article_comment_edit_history(self):
+        article_response = self.create_an_article(
+            self.article, self.registration_data)
+        slug = article_response.data["slug"]
+        post_response = self.client.post(
+            "/api/articles/{}/comments/".format(str(slug)),
+            self.comment_data, format="json")
+        comment_id = post_response.data["id"]
+        self.client.put(
+            "/api/articles/{}/comments/{}/".format(str(slug), comment_id),
+            self.change_comment, format="json")
+        self.client.put(
+            "/api/articles/{}/comments/{}/".format(str(slug), comment_id),
+            self.change_comment, format="json")
+        response = self.client.get(
+            "/api/articles/{}/comments/{}/history/".format(str(slug),
+                                                           comment_id),
+            self.change_comment, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_can_not_get_edit_history_when_comment_is_not_edited(self):
+        article_response = self.create_an_article(
+            self.article, self.registration_data)
+        slug = article_response.data["slug"]
+        post_response = self.client.post(
+            "/api/articles/{}/comments/".format(str(slug)),
+            self.comment_data, format="json")
+        comment_id = post_response.data["id"]
+        response = self.client.get(
+            "/api/articles/{}/comments/{}/history/".format(str(slug),
+                                                           comment_id),
+            self.change_comment, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
#### **What does this PR do?**
- tracks users comment edit history

#### **Description of Task to be completed?**
- tracks users comment edit history

#### **How should this be manually tested?**
- Login and retrieve an access token
- Use this token to create articles
- After creating articles, post a comment about an article.
- Make changes to that comment.
- View the edit history of that comment using the endpoint
     GET `/api/articles/<str:slug>/comments/<int:id>/history/` 
#### **Any background context you want to provide?**
- User must have edited an article twice

#### **Screenshots**
<img width="1145" alt="Screenshot 2019-03-18 at 20 57 49" src="https://user-images.githubusercontent.com/29123354/54552169-87a81980-49c0-11e9-91a1-562932dc0f7d.png">

#### **What are the relevant pivotal tracker stories?**
 #164069329