### PR TITLE
#164069331 Enables users to see their reading stats

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -78,6 +78,7 @@ class Article(models.Model):
     votes = GenericRelation(LikeDislike, related_name='articles')
     user_rates = models.CharField(max_length=10, default=0)
     reading_time = models.CharField(null=True, max_length=100)
+    read_stats = models.IntegerField(default=0)
 
     def __str__(self):
         return self.title
@@ -181,3 +182,16 @@ class ReportedArticle(models.Model):
 
     class Meta:
         ordering = ['-reported_at']
+
+
+class ReadingStats(models.Model):
+    article = models.ForeignKey(Article, on_delete=models.CASCADE,
+                                blank=True)
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    read_stats = models.IntegerField(default=0)
+
+    def __str__(self):
+        return "article_title: {}, user: {}, read_stats: {}".format(
+            self.article,
+            self.user,
+            self.read_stats)

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 from .models import (Category, Article,
                      ReportedArticle,
                      Bookmark, Rating, Comment,
-                     Tag, CommentHistory)
+                     Tag, CommentHistory, ReadingStats)
 from ..profiles.serializers import ProfileSerializer
 from ..profiles.models import Profile
 from authors.apps.authentication.models import User
@@ -34,6 +34,7 @@ class ArticleSerializer(serializers.ModelSerializer):
     likes = serializers.SerializerMethodField()
     dislikes = serializers.SerializerMethodField()
     tagList = TagsRelationSerializer(many=True, required=False, source='tags')
+    read_stats = serializers.SerializerMethodField()
 
     class Meta:
         model = Article
@@ -54,7 +55,8 @@ class ArticleSerializer(serializers.ModelSerializer):
             'tagList',
             'likes',
             'dislikes',
-            'reading_time'
+            'reading_time',
+            'read_stats'
         )
         read_only_fields = ('id', 'slug', 'author_id', 'is_published',)
         user_rating = serializers.CharField(
@@ -95,6 +97,9 @@ class ArticleSerializer(serializers.ModelSerializer):
     """Gets all the articles dislikes"""
     def get_dislikes(self, instance):
         return instance.votes.dislikes().count()
+
+    def get_read_stats(self, instance):
+        return ReadingStats.objects.filter(article=instance).count()
 
 
 class BookmarkSerializer(serializers.ModelSerializer):
@@ -235,3 +240,10 @@ class CommentHistorySerializer(serializers.ModelSerializer):
         fields = (
             'body',
             'updated_at',)
+
+
+class ReadStatsSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ReadingStats
+        fields = ('user', 'article', 'read_stats')
+        read_only = ('author', 'article')

--- a/authors/apps/profiles/renderers.py
+++ b/authors/apps/profiles/renderers.py
@@ -3,3 +3,7 @@ from ..renderers import MainRenderer
 
 class ProfileJSONRenderer(MainRenderer):
     object_label = 'profile'
+
+
+class ReadingStatsJSONRenderer(MainRenderer):
+    object_label = 'readstat'

--- a/authors/apps/profiles/urls.py
+++ b/authors/apps/profiles/urls.py
@@ -4,7 +4,8 @@ from .views import (
     ListProfileView,
     FollowProfileView,
     FollowersListView,
-    FollowingListView
+    FollowingListView,
+    ReadingStatsView
 )
 
 urlpatterns = [
@@ -12,5 +13,6 @@ urlpatterns = [
     path('profiles/', ListProfileView.as_view()),
     path('profiles/<str:username>/follow/', FollowProfileView.as_view()),
     path('profiles/<str:username>/followers/', FollowersListView.as_view()),
-    path('profiles/<str:username>/following/', FollowingListView.as_view())
+    path('profiles/<str:username>/following/', FollowingListView.as_view()),
+    path('profile/<username>/read_stats/', ReadingStatsView.as_view())
 ]

--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -9,10 +9,13 @@ from rest_framework.permissions import (
     IsAuthenticatedOrReadOnly,
     AllowAny
 )
-from .renderers import ProfileJSONRenderer
+from .renderers import ProfileJSONRenderer, ReadingStatsJSONRenderer
 from .permissions import IsOwnerOrReadOnly
 from .serializers import ProfileSerializer
+from authors.apps.articles.serializers import ReadStatsSerializer
 from .models import Profile
+from authors.apps.articles.models import ReadingStats
+from authors.apps.authentication.models import User
 from rest_framework import status, serializers
 from rest_framework.response import Response
 from django.shortcuts import get_object_or_404
@@ -133,3 +136,38 @@ class FollowersListView(FollowersFollowingView):
 class FollowingListView(FollowersFollowingView):
     def get_queryset(self, *args, **kwargs):
         return self.get_profile().follows.all()
+
+
+class ReadingStatsView(ListAPIView):
+    """
+    class view that reurns a list of articles read by one user
+    """
+    serializer_class = ReadStatsSerializer
+    permission_classes = (IsAuthenticated,)
+    renderer_classes = [ReadingStatsJSONRenderer, ]
+
+    def get_queryset(self, *args, **kwargs):
+
+        username = self.kwargs.get('username')
+        author = get_object_or_404(User, username=username)
+        read_stats = ReadingStats.objects.all().filter(user=author)
+        return [item.article for item in read_stats]
+
+    def get(self, request, username):
+        list_of_articles = -20
+        if username == request.user.username:
+            articles = self.get_queryset()
+            list_of_articles = [{'title': article.title,
+                                 'slug': article.slug,
+                                 'author': article.author.username}
+                                for article in articles[list_of_articles:]]
+            data = {
+                'user': request.user.username,
+                'No_of_Read_articles': len(articles),
+                'Most_recent_articles': list(reversed(list_of_articles))
+            }
+            return Response(data)
+        else:
+            return Response({
+                'error_message': 'You cannot access this route'
+            }, status=status.HTTP_403_FORBIDDEN)

--- a/tests/profiles/test_read_stats.py
+++ b/tests/profiles/test_read_stats.py
@@ -1,0 +1,35 @@
+from rest_framework import status
+from ..test_base import BaseTest
+from tests.articles.test_category import TestCategory
+
+
+class TestRateArticle(BaseTest, TestCategory):
+
+    def test_read_stats_of_your_own_article(self):
+        data = self.create_an_article(
+            self.new_article,
+            self.registration_data)
+        token = self.register_and_login(self.another_user_data)
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + token.data['token'])
+        self.client.get('/api/articles/{}/'.
+                        format(data.data['slug']),
+                        format="json")
+        response = self.client.get('/api/profile/{}/read_stats/')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data['error_message'],
+                         'You cannot access this route')
+
+    def test_read_stats_of_an_article(self):
+        data = self.create_an_article(
+            self.new_article,
+            self.registration_data)
+        token = self.register_and_login(self.another_user_data)
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Bearer ' + token.data['token'])
+        self.client.get('/api/articles/{}/'.
+                        format(data.data['slug']),
+                        format="json")
+
+        response = self.client.get('/api/profile/user1/read_stats/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
**What does this PR do?**
* Implements ability of a user to see their reading stats

**Description of the tasks to be completed?**
* Create a read_stats field that will handle the data from the calculated number of times the article has been read.
* Create a view that will handle the endpoint that retrieves the calculated statistics.
add logic for when the article is read

**How should this be manaully tested?**
* Fetch this branch by running the command git fetch origin ft-see-reading-stats-164069331 in the terminal and check into the branch git checkout ft-see-reading-stats-164069331
* Start the virtual environment source venv/bin/activate
* Migrate to add new files to the database, `python manage.py migrate`
* Start the application `python manage.py runserver`
* create an article `api/arcticle` an then log out and login in as a different user and then read that article, you will see that the statistics change
**screenshots

`Gets articles for reading api/articles/slug/`
<img width="1440" alt="Screenshot 2019-03-19 at 14 01 28" src="https://user-images.githubusercontent.com/42295880/54601215-8b36b180-4a4f-11e9-85ca-620d6b864330.png">

`Getting readstats api/profile/username/read_stats/`
<img width="1440" alt="Screenshot 2019-03-19 at 14 07 53" src="https://user-images.githubusercontent.com/42295880/54601606-7dcdf700-4a50-11e9-9c04-cc944def748e.png">


**What are the relevant pivot tracker stores?**
#164069331